### PR TITLE
gromacs support

### DIFF
--- a/GmxTests/01.1water/shot.mdp
+++ b/GmxTests/01.1water/shot.mdp
@@ -12,8 +12,9 @@ xtc_grps        = System
 energygrps      = System
 comm_mode       = linear
 
+cutoff-scheme = group
 nstlist		= 0
-ns_type		= simple
+ns-type		= simple
 rlist		= 0.0
 vdwtype		= cut-off
 coulombtype	= cut-off

--- a/GmxTests/02.6water/shot.mdp
+++ b/GmxTests/02.6water/shot.mdp
@@ -21,6 +21,7 @@ rvdw            = 0.0
 rvdw_switch     = 0.0
 constraints     = h-bonds
 pbc             = no
+cutoff-scheme   = group
 
 tcoupl          = v-rescale
 tc_grps         = System

--- a/GmxTests/03.AlaGlu/shot.mdp
+++ b/GmxTests/03.AlaGlu/shot.mdp
@@ -17,3 +17,4 @@ rcoulomb	= 0.0
 rvdw		= 0.0
 constraints	= none
 pbc		= no
+cutoff-scheme   = group

--- a/GmxTests/04.Ala/shot.mdp
+++ b/GmxTests/04.Ala/shot.mdp
@@ -17,4 +17,4 @@ rcoulomb	= 0.0
 rvdw		= 0.0
 constraints	= none
 pbc		= no
-
+cutoff-scheme   = group

--- a/GmxTests/05.Asp/shot.mdp
+++ b/GmxTests/05.Asp/shot.mdp
@@ -17,4 +17,4 @@ rcoulomb	= 0.0
 rvdw		= 0.0
 constraints	= none
 pbc		= no
-
+cutoff-scheme   = group

--- a/GmxTests/06.DHFR-Gas/shot.mdp
+++ b/GmxTests/06.DHFR-Gas/shot.mdp
@@ -17,4 +17,5 @@ rcoulomb	= 0.0
 rvdw		= 0.0
 constraints	= none
 pbc		= no
+cutoff-scheme   = group
 

--- a/GmxTests/07.DHFR-Liquid-NoPBC/shot.mdp
+++ b/GmxTests/07.DHFR-Liquid-NoPBC/shot.mdp
@@ -17,4 +17,5 @@ rcoulomb	= 0.0
 rvdw		= 0.0
 constraints	= h-bonds
 pbc		= no
+cutoff-scheme   = group
 

--- a/GmxTests/test.py
+++ b/GmxTests/test.py
@@ -34,12 +34,12 @@ import simtk.openmm.app as app
 
 # Gromacs settings
 gmxsuffix=""
-if which('mdrun'+gmxsuffix) != '':
-    gmxpath = which('mdrun'+gmxsuffix)
-    GMXVERSION = 4
-elif which('gmx'+gmxsuffix) != '':
+if which('gmx'+gmxsuffix) != '':
     gmxpath = which('gmx'+gmxsuffix)
     GMXVERSION = 5
+elif which('mdrun'+gmxsuffix) != '':
+    gmxpath = which('mdrun'+gmxsuffix)
+    GMXVERSION = 4
 else:
     logger.error("Cannot find the GROMACS executables!\n")
     raise RuntimeError

--- a/GmxTests/test.py
+++ b/GmxTests/test.py
@@ -157,7 +157,7 @@ def callgmx(command, stdin=None, print_to_screen=False, print_command=False, **k
     rm_gmx_baks(os.getcwd())
     # Call a GROMACS program as you would from the command line.
     if GMXVERSION == 5:
-        csplit = ('gmx ' + command).split()
+        csplit = ('gmx ' + command.replace('gmx', '')).split()
     else:
         if not command.startswith('mdrun'):
             csplit = ('g_%s' % command).split()
@@ -261,7 +261,7 @@ def Calculate_GMX(gro_file, top_file, mdp_file):
     # Call grompp to set up calculation.
     callgmx("grompp -f enerfrc.mdp -c %s -p %s -maxwarn 1" % (gro_file, top_file))
     # Run gmxdump to determine which atoms are real.
-    o = callgmx("dump -s topol.tpr -sys", copy_stderr=True)
+    o = callgmx("gmxdump -s topol.tpr -sys", copy_stderr=True)
     AtomMask = []
     for line in o:
         line = line.replace("=", "= ")


### PR DESCRIPTION
Hi @leeping,

I've recently installed Gromacs, and I'm working with their main git repository.  They made a substantial change to their code -- they now only have _one_ program, `gmx`, which takes as arguments sub-programs (like `mdrun`, or `grompp`).  So, for instance, instead of running `g_energy <args>` you would run `gmx energy <args>`.

This PR updates test.py in a way that works for the current TOT gromacs (and autodetects the Gromacs version from the available binaries). It also turns off double-precision, since I didn't install that version -- you can always turn the suffix back to `_d`, and that will be handled correctly.
